### PR TITLE
Add TCP congestion control tracking hook

### DIFF
--- a/config/start_overrides.yaml
+++ b/config/start_overrides.yaml
@@ -20,3 +20,4 @@ collector_config:
       - quanta_runtime
       - block_io
       - perf
+      - tcp_congestion_control

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -48,3 +48,4 @@ collector_config:
       - tcp_v4_rcv
       - tcp_state_process
       - tcp_v4_connect
+      - tcp_congestion_control

--- a/python/kernmlops/data_collection/bpf_instrumentation/__init__.py
+++ b/python/kernmlops/data_collection/bpf_instrumentation/__init__.py
@@ -31,6 +31,9 @@ from data_collection.bpf_instrumentation.tcp_v4_connect_hook import TcpV4Connect
 from data_collection.bpf_instrumentation.tcp_v4_rcv_hook import TcpV4RcvBPFHook
 from data_collection.bpf_instrumentation.unmap_range import UnmapRangeBPFHook
 from data_collection.bpf_instrumentation.zswap_runtime_hook import ZswapRuntimeBPFHook
+from data_collection.bpf_instrumentation.tcp_congestion_control_hook import (
+    TcpCongestionControlBPFHook,
+)
 
 all_hooks: Final[Mapping[str, type[BPFProgram]]] = {
     FileDataBPFHook.name(): FileDataBPFHook,
@@ -50,6 +53,7 @@ all_hooks: Final[Mapping[str, type[BPFProgram]]] = {
     TcpV4RcvBPFHook.name(): TcpV4RcvBPFHook,
     TcpStateProcessBPFHook.name(): TcpStateProcessBPFHook,
     TcpV4ConnectBPFHook.name(): TcpV4ConnectBPFHook,
+    TcpCongestionControlBPFHook.name(): TcpCongestionControlBPFHook,
 }
 
 def hook_names() -> list[str]:

--- a/python/kernmlops/data_collection/bpf_instrumentation/bpf/tcp_congestion_control.bpf.c
+++ b/python/kernmlops/data_collection/bpf_instrumentation/bpf/tcp_congestion_control.bpf.c
@@ -1,0 +1,134 @@
+#include <linux/bpf.h>
+#include <linux/sched.h>
+#include <linux/tcp.h>
+#include <net/sock.h>
+#include <net/inet_connection_sock.h>
+#include <net/tcp.h>
+#include <uapi/linux/ptrace.h>
+
+#define TCP_CA_NAME_MAX 16
+#define TASK_COMM_LEN 16
+
+// Event types
+#define EVENT_ASSIGN_CC     1
+#define EVENT_INIT_CC       2
+#define EVENT_SET_CC        3
+#define EVENT_REINIT_CC     4
+#define EVENT_CLEANUP_CC    5
+
+struct cc_event {
+    u32 pid;
+    u32 tgid;
+    u64 ts_uptime_us;
+    u8 event_type;
+    char ca_name[TCP_CA_NAME_MAX];
+    char comm[TASK_COMM_LEN];
+    u32 saddr;
+    u32 daddr;
+    u16 sport;
+    u16 dport;
+};
+
+BPF_PERF_OUTPUT(cc_events);
+BPF_HASH(socket_tracking, struct sock*, struct cc_event);
+
+// Helper to extract connection info from socket
+static inline void get_conn_info(struct sock *sk, struct cc_event *event) {
+    struct inet_sock *inet = (struct inet_sock *)sk;
+    bpf_probe_read_kernel(&event->saddr, sizeof(event->saddr), &inet->inet_saddr);
+    bpf_probe_read_kernel(&event->daddr, sizeof(event->daddr), &inet->inet_daddr);
+    bpf_probe_read_kernel(&event->sport, sizeof(event->sport), &inet->inet_sport);
+    bpf_probe_read_kernel(&event->dport, sizeof(event->dport), &inet->inet_dport);
+}
+
+int trace_assign_cc(struct pt_regs *ctx, struct sock *sk) {
+    struct cc_event event = {};
+    struct inet_connection_sock *icsk;
+    struct tcp_congestion_ops *ca_ops;
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    event.pid = pid_tgid;
+    event.tgid = pid_tgid >> 32;
+    event.ts_uptime_us = bpf_ktime_get_ns() / 1000;
+    event.event_type = EVENT_ASSIGN_CC;
+    bpf_get_current_comm(&event.comm, sizeof(event.comm));
+    icsk = (struct inet_connection_sock *)sk;
+    bpf_probe_read_kernel(&ca_ops, sizeof(ca_ops), &icsk->icsk_ca_ops);
+    if (ca_ops) {
+        bpf_probe_read_kernel_str(&event.ca_name, sizeof(event.ca_name), &ca_ops->name);
+    }
+    get_conn_info(sk, &event);
+    socket_tracking.update(&sk, &event);
+    cc_events.perf_submit(ctx, &event, sizeof(event));
+    return 0;
+}
+
+int trace_init_cc(struct pt_regs *ctx, struct sock *sk) {
+    struct cc_event event = {};
+    struct inet_connection_sock *icsk;
+    struct tcp_congestion_ops *ca_ops;
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    event.pid = pid_tgid;
+    event.tgid = pid_tgid >> 32;
+    event.ts_uptime_us = bpf_ktime_get_ns() / 1000;
+    event.event_type = EVENT_INIT_CC;
+    bpf_get_current_comm(&event.comm, sizeof(event.comm));
+    icsk = (struct inet_connection_sock *)sk;
+    bpf_probe_read_kernel(&ca_ops, sizeof(ca_ops), &icsk->icsk_ca_ops);
+    if (ca_ops) {
+        bpf_probe_read_kernel_str(&event.ca_name, sizeof(event.ca_name), &ca_ops->name);
+    }
+    get_conn_info(sk, &event);
+    cc_events.perf_submit(ctx, &event, sizeof(event));
+    return 0;
+}
+
+int trace_set_cc(struct pt_regs *ctx, struct sock *sk, const char *name) {
+    struct cc_event event = {};
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    event.pid = pid_tgid;
+    event.tgid = pid_tgid >> 32;
+    event.ts_uptime_us = bpf_ktime_get_ns() / 1000;
+    event.event_type = EVENT_SET_CC;
+    bpf_get_current_comm(&event.comm, sizeof(event.comm));
+    bpf_probe_read_user_str(&event.ca_name, sizeof(event.ca_name), name);
+    get_conn_info(sk, &event);
+    cc_events.perf_submit(ctx, &event, sizeof(event));
+    return 0;
+}
+
+int trace_reinit_cc(struct pt_regs *ctx, struct sock *sk, struct tcp_congestion_ops *ca) {
+    struct cc_event event = {};
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    event.pid = pid_tgid;
+    event.tgid = pid_tgid >> 32;
+    event.ts_uptime_us = bpf_ktime_get_ns() / 1000;
+    event.event_type = EVENT_REINIT_CC;
+    bpf_get_current_comm(&event.comm, sizeof(event.comm));
+    if (ca) {
+        bpf_probe_read_kernel_str(&event.ca_name, sizeof(event.ca_name), &ca->name);
+    }
+    get_conn_info(sk, &event);
+    cc_events.perf_submit(ctx, &event, sizeof(event));
+    return 0;
+}
+
+int trace_cleanup_cc(struct pt_regs *ctx, struct sock *sk) {
+    struct cc_event event = {};
+    struct inet_connection_sock *icsk;
+    struct tcp_congestion_ops *ca_ops;
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    event.pid = pid_tgid;
+    event.tgid = pid_tgid >> 32;
+    event.ts_uptime_us = bpf_ktime_get_ns() / 1000;
+    event.event_type = EVENT_CLEANUP_CC;
+    bpf_get_current_comm(&event.comm, sizeof(event.comm));
+    icsk = (struct inet_connection_sock *)sk;
+    bpf_probe_read_kernel(&ca_ops, sizeof(ca_ops), &icsk->icsk_ca_ops);
+    if (ca_ops) {
+        bpf_probe_read_kernel_str(&event.ca_name, sizeof(event.ca_name), &ca_ops->name);
+    }
+    get_conn_info(sk, &event);
+    socket_tracking.delete(&sk);
+    cc_events.perf_submit(ctx, &event, sizeof(event));
+    return 0;
+}

--- a/python/kernmlops/data_collection/bpf_instrumentation/tcp_congestion_control_hook.py
+++ b/python/kernmlops/data_collection/bpf_instrumentation/tcp_congestion_control_hook.py
@@ -1,0 +1,112 @@
+from dataclasses import dataclass
+from pathlib import Path
+import socket
+import struct
+
+import polars as pl
+from bcc import BPF
+
+from data_collection.bpf_instrumentation.bpf_hook import POLL_TIMEOUT_MS, BPFProgram
+from data_schema import CollectionTable
+
+EVENT_NAMES = {
+    1: "ASSIGN",
+    2: "INIT",
+    3: "SET",
+    4: "REINIT",
+    5: "CLEANUP",
+}
+
+
+@dataclass(frozen=True)
+class TcpCongestionEvent:
+    cpu: int
+    pid: int
+    tgid: int
+    ts_uptime_us: int
+    event_type: int
+    event_type_name: str
+    ca_name: str
+    saddr: str
+    daddr: str
+    sport: int
+    dport: int
+    comm: str
+
+
+class TcpCongestionControlBPFHook(BPFProgram):
+
+    @classmethod
+    def name(cls) -> str:
+        return "tcp_congestion_control"
+
+    def __init__(self):
+        bpf_text = open(Path(__file__).parent / "bpf/tcp_congestion_control.bpf.c", "r").read()
+        self.bpf_text = bpf_text
+        self.events = list[TcpCongestionEvent]()
+
+    def load(self, collection_id: str):
+        self.collection_id = collection_id
+        self.bpf = BPF(text=self.bpf_text)
+
+        # Attach core congestion control functions
+        self.bpf.attach_kprobe(event=b"tcp_assign_congestion_control", fn_name=b"trace_assign_cc")
+        self.bpf.attach_kprobe(event=b"tcp_init_congestion_control", fn_name=b"trace_init_cc")
+        self.bpf.attach_kprobe(event=b"tcp_set_congestion_control", fn_name=b"trace_set_cc")
+        try:
+            self.bpf.attach_kprobe(event=b"tcp_reinit_congestion_control", fn_name=b"trace_reinit_cc")
+        except Exception:
+            pass
+        self.bpf.attach_kprobe(event=b"tcp_cleanup_congestion_control", fn_name=b"trace_cleanup_cc")
+
+        self.bpf["cc_events"].open_perf_buffer(self._event_handler, page_cnt=64)
+
+    def poll(self):
+        self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
+
+    def close(self):
+        self.bpf.cleanup()
+
+    def _event_handler(self, cpu, data, size):
+        event = self.bpf["cc_events"].event(data)
+
+        saddr = socket.inet_ntoa(struct.pack('I', event.saddr)) if event.saddr else "0.0.0.0"
+        daddr = socket.inet_ntoa(struct.pack('I', event.daddr)) if event.daddr else "0.0.0.0"
+        sport = socket.ntohs(event.sport) if event.sport else 0
+        dport = socket.ntohs(event.dport) if event.dport else 0
+        ca_name = event.ca_name.decode('utf-8', 'replace').rstrip('\x00')
+        comm = event.comm.decode('utf-8', 'replace').rstrip('\x00')
+
+        self.events.append(
+            TcpCongestionEvent(
+                cpu=cpu,
+                pid=event.pid,
+                tgid=event.tgid,
+                ts_uptime_us=event.ts_uptime_us,
+                event_type=event.event_type,
+                event_type_name=EVENT_NAMES.get(event.event_type, f"EVENT_{event.event_type}"),
+                ca_name=ca_name,
+                saddr=saddr,
+                daddr=daddr,
+                sport=sport,
+                dport=dport,
+                comm=comm,
+            )
+        )
+
+    def data(self) -> list[CollectionTable]:
+        from data_schema.tcp_congestion_control import TcpCongestionControlTable
+        if len(self.events) == 0:
+            return []
+        events_df = pl.DataFrame(self.events)
+        return [
+            TcpCongestionControlTable.from_df_id(events_df, collection_id=self.collection_id)
+        ]
+
+    def clear(self):
+        self.events.clear()
+
+    def pop_data(self) -> list[CollectionTable]:
+        tables = self.data()
+        self.clear()
+        return tables

--- a/python/kernmlops/data_schema/__init__.py
+++ b/python/kernmlops/data_schema/__init__.py
@@ -25,6 +25,7 @@ from data_schema.schema import (
 from data_schema.tcp_state_process import TcpStateProcessTable, TcpStateStatsTable
 from data_schema.tcp_v4_connect import TcpConnectStatsTable, TcpV4ConnectTable
 from data_schema.tcp_v4_rcv import TcpV4RcvTable
+from data_schema.tcp_congestion_control import TcpCongestionControlTable
 
 table_types: list[type[CollectionTable]] = [
     SystemInfoTable,
@@ -43,6 +44,7 @@ table_types: list[type[CollectionTable]] = [
     TcpStateStatsTable,
     TcpV4ConnectTable,
     TcpConnectStatsTable,
+    TcpCongestionControlTable,
 ] + list(perf.perf_table_types.values())
 
 

--- a/python/kernmlops/data_schema/tcp_congestion_control.py
+++ b/python/kernmlops/data_schema/tcp_congestion_control.py
@@ -1,0 +1,47 @@
+import polars as pl
+from data_schema.schema import (
+    UPTIME_TIMESTAMP,
+    CollectionGraph,
+    CollectionTable,
+)
+
+
+class TcpCongestionControlTable(CollectionTable):
+    """Table for TCP congestion control events"""
+
+    @classmethod
+    def name(cls) -> str:
+        return "tcp_congestion_control"
+
+    @classmethod
+    def schema(cls) -> pl.Schema:
+        return pl.Schema({
+            UPTIME_TIMESTAMP: pl.Int64(),
+            "pid": pl.Int32(),
+            "tgid": pl.Int32(),
+            "event_type": pl.Int8(),
+            "event_type_name": pl.Utf8(),
+            "ca_name": pl.Utf8(),
+            "saddr": pl.Utf8(),
+            "daddr": pl.Utf8(),
+            "sport": pl.Int32(),
+            "dport": pl.Int32(),
+            "comm": pl.Utf8(),
+        })
+
+    @classmethod
+    def from_df(cls, table: pl.DataFrame) -> "TcpCongestionControlTable":
+        return TcpCongestionControlTable(table=table)
+
+    def __init__(self, table: pl.DataFrame):
+        self._table = table
+
+    @property
+    def table(self) -> pl.DataFrame:
+        return self._table
+
+    def filtered_table(self) -> pl.DataFrame:
+        return self.table
+
+    def graphs(self) -> list[type[CollectionGraph]]:
+        return []


### PR DESCRIPTION
## Summary
- add eBPF program to observe TCP congestion control algorithm changes
- expose congestion events via a new BPF hook and data schema
- enable the hook in default and start configurations

## Testing
- `ruff check python/kernmlops/data_collection/bpf_instrumentation/tcp_congestion_control_hook.py python/kernmlops/data_schema/tcp_congestion_control.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68962503550c832ba10a11fab7fa9f73